### PR TITLE
Update and rename LICENSE.txt to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2014 Auth0 Inc.
+Copyright (c) 2015 Auth0, Inc. <support@auth0.com> (http://auth0.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
License contents updated, and filename drops txt extension.

Fixes https://github.com/auth0/gapps-directory/issues/2